### PR TITLE
fix auth flicker and duplicate api calls

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import { type Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { Toaster } from "sonner";
+import { AuthProvider } from "@/utils/useAuth";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -63,7 +64,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Toaster />
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,9 +10,9 @@ export default function Page() {
 
   useEffect(() => {
     if (isAuthenticated) {
-      router.push("/signin");
-    } else {
       router.push("/home");
+    } else {
+      router.push("/signin");
     }
   }, [isAuthenticated, router]);
 


### PR DESCRIPTION
## Summary
- centralize authentication state in a context to avoid duplicate API calls
- wrap application with new AuthProvider
- fix home routing to send users to the correct page based on auth status

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(prompts for interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ad2b609354832baa06448934f2561c