### PR TITLE
feat: add blog meta fields

### DIFF
--- a/app/(main)/blog/[slug]/edit/page.tsx
+++ b/app/(main)/blog/[slug]/edit/page.tsx
@@ -5,6 +5,8 @@ import { useRouter, useParams } from "next/navigation";
 import axios from "axios";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import { X } from "lucide-react";
 import { ImageUploader } from "@/components/ImageUploader";
 import { useAuth } from "@/utils/useAuth";
@@ -26,6 +28,8 @@ export default function EditBlogPage() {
   const [tagInput, setTagInput] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [imageUrl, setImageUrl] = useState("");
+  const [metaTitle, setMetaTitle] = useState("");
+  const [metaDescription, setMetaDescription] = useState("");
   const [loading, setLoading] = useState(false);
 
   const router = useRouter();
@@ -65,6 +69,8 @@ export default function EditBlogPage() {
       setTags(blog.tags || []);
       setImageUrl(blog.image || "");
       setContent(blog.content);
+      setMetaTitle(blog.metaTitle || "");
+      setMetaDescription(blog.metaDescription || "");
       localStorage.setItem("html-content", blog.content);
     } catch (err) {
       console.error(err);
@@ -111,6 +117,8 @@ export default function EditBlogPage() {
           content: editorContent,
           tags,
           image: imageUrl,
+          metaTitle,
+          metaDescription,
         },
         { withCredentials: true }
       );
@@ -136,6 +144,19 @@ export default function EditBlogPage() {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           className="w-full text-5xl font-bold border-none focus:outline-none placeholder:text-gray-400"
+        />
+
+        <Input
+          type="text"
+          placeholder="Meta Title"
+          value={metaTitle}
+          onChange={(e) => setMetaTitle(e.target.value)}
+        />
+
+        <Textarea
+          placeholder="Meta Description"
+          value={metaDescription}
+          onChange={(e) => setMetaDescription(e.target.value)}
         />
 
         {/* Image Upload */}

--- a/app/(main)/blog/[slug]/page.tsx
+++ b/app/(main)/blog/[slug]/page.tsx
@@ -31,21 +31,24 @@ export async function generateMetadata({ params }: any): Promise<Metadata> {
     };
   }
 
-  const cleanDescription = blog.content.replace(/<[^>]+>/g, "").slice(0, 160);
-  const cleanTitle = he.decode(blog.title);
+  const cleanDescription = blog.content
+    .replace(/<[^>]+>/g, "")
+    .slice(0, 160);
+  const title = he.decode(blog.metaTitle || blog.title);
+  const description = blog.metaDescription || cleanDescription;
 
   return {
-    title: cleanTitle,
-    description: cleanDescription,
+    title,
+    description,
     openGraph: {
-      title: cleanTitle,
-      description: cleanDescription,
+      title,
+      description,
       images: [blog.image],
     },
     twitter: {
       card: "summary_large_image",
-      title: cleanTitle,
-      description: cleanDescription,
+      title,
+      description,
       images: [blog.image],
     },
   };

--- a/app/(main)/blog/add/page.tsx
+++ b/app/(main)/blog/add/page.tsx
@@ -6,7 +6,6 @@ import axios from "axios";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { X } from "lucide-react";
 import {
@@ -19,7 +18,6 @@ import {
 import { ImageUploader } from "@/components/ImageUploader";
 import { useAuth } from "@/utils/useAuth";
 import TailwindAdvancedEditor from "@/components/advanced-editor";
-import Link from "next/link";
 import { toast } from "sonner";
 
 export default function AddBlogPage() {
@@ -30,6 +28,8 @@ export default function AddBlogPage() {
   const [tagInput, setTagInput] = useState("");
   const [tags, setTags] = useState<string[]>([]);
   const [imageUrl, setImageUrl] = useState("");
+  const [metaTitle, setMetaTitle] = useState("");
+  const [metaDescription, setMetaDescription] = useState("");
   const [loading, setLoading] = useState(false);
 
   const router = useRouter();
@@ -107,6 +107,8 @@ export default function AddBlogPage() {
           content: editorContent,
           tags,
           image: imageUrl,
+          metaTitle,
+          metaDescription,
           author: user?.name || user?.email,
           authorId: user?.userId,
         },
@@ -130,6 +132,19 @@ export default function AddBlogPage() {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           className="w-full text-5xl font-bold border-none focus:outline-none placeholder:text-gray-400"
+        />
+
+        <Input
+          type="text"
+          placeholder="Meta Title"
+          value={metaTitle}
+          onChange={(e) => setMetaTitle(e.target.value)}
+        />
+
+        <Textarea
+          placeholder="Meta Description"
+          value={metaDescription}
+          onChange={(e) => setMetaDescription(e.target.value)}
         />
 
         <ImageUploader onUpload={(url) => setImageUrl(url)} />

--- a/app/(main)/blog/category/[category]/page.tsx
+++ b/app/(main)/blog/category/[category]/page.tsx
@@ -11,6 +11,8 @@ export interface BlogInterface {
   slug?: string;
   authorId?: string;
   createdAt?: string;
+  metaTitle?: string;
+  metaDescription?: string;
   likes: any;
   comment: any;
 }

--- a/app/(main)/home/page.tsx
+++ b/app/(main)/home/page.tsx
@@ -11,6 +11,8 @@ export interface BlogInterface {
   slug?: string;
   authorId?: string;
   createdAt?: string;
+  metaTitle?: string;
+  metaDescription?: string;
   likes: any;
   comment: any;
 }

--- a/app/api/blog/[slug]/route.ts
+++ b/app/api/blog/[slug]/route.ts
@@ -36,7 +36,16 @@ export async function PUT(
   try {
     await connectDB();
     const { slug } = await context.params;
-    const { title, content, tags, image, author, category } = await req.json();
+    const {
+      title,
+      content,
+      tags,
+      image,
+      author,
+      category,
+      metaTitle,
+      metaDescription,
+    } = await req.json();
 
     if (!title || !content || !image || !author || !category) {
       return NextResponse.json(
@@ -59,6 +68,8 @@ export async function PUT(
         image,
         author,
         category,
+        metaTitle,
+        metaDescription,
       },
       { new: true }
     );

--- a/app/api/blog/route.ts
+++ b/app/api/blog/route.ts
@@ -25,8 +25,16 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: "Invalid token" }, { status: 401 });
     }
 
-    const { title, content, category, tags, image, authorId } =
-      await req.json();
+    const {
+      title,
+      content,
+      category,
+      tags,
+      image,
+      authorId,
+      metaTitle,
+      metaDescription,
+    } = await req.json();
 
     if (!title || !content || !category) {
       return NextResponse.json(
@@ -51,6 +59,8 @@ export async function POST(req: NextRequest) {
       category,
       tags,
       image,
+      metaTitle,
+      metaDescription,
       author: decoded.name || decoded.email,
       authorId: decoded.userId,
     });

--- a/models/blog.ts
+++ b/models/blog.ts
@@ -10,6 +10,8 @@ const blogSchema = new Schema(
     authorId: { type: String, required: true },
     tags: { type: [String] },
     image: { type: String },
+    metaTitle: { type: String },
+    metaDescription: { type: String },
     status: { type: String, enum: ["Draft", "Published", "Pending", "Hide"] },
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- add optional `metaTitle` and `metaDescription` fields to blog schema and APIs
- expose meta fields in add and edit blog forms and metadata generation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: interactive configuration prompt)
- `npm run build` (fails: network error fetching fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b1e1bccd28832b800d5dd54af6af55